### PR TITLE
Removing crypto currency wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ SSH Configuration - Changelog
 ==============
 A list of all the changes made to this cookbook
 
+Version 0.1.6
+------------
+1. Removing stale cryptocurrency wallets from donation section of README
+
 Version 0.1.5
 ------------
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,8 @@ Use Cases
 ------------
 Configuring SSH as part of a base security requirement
 
-Donate To Support This Chef Cookbook
+Donate To Support These Vagrant Boxes
 ------------
-Route 1337, LLC operates entirely on donations. If you find this cookbook useful, please consider donating via one of these methods.
-
-1. Bitcoin: 1CnzzrPh3iirEkLRLiWFKXDV9i5TXHQjE2
-2. Bitcoin Cash: qzcq645swgd87s7t5mmmjcumf4armhtjt5euww5c29
-3. Litecoin: LWYbc9hf5ErJsF874Q3wwmMiASHRWgwrjR
-4. Ethereum: 0x117543aa7a4D704849171cA06568Ece71B111D18
+Route 1337, LLC operates entirely on donations. If you find these scripts useful, please consider [contacting us](https://www.route1337.com/contact-us/) about how to donate.
 
 Thank you for your support!

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'matthew@route1337.com'
 license 'MIT'
 description 'Configure OpenSSH with standard or hardened settings'
 long_description 'This Chef cookbook will configure SSH on Linux servers to be compliant with Route 1337 security policies. There are a few versions of the configuration depending on the recipe that is chosen'
-version '0.1.5'
+version '0.1.6'
 chef_version '>= 13.6.4' if respond_to?(:chef_version)
 depends          'openssh'
 issues_url 'https://github.com/route1337/chef-cookbook-sshconfig/issues'


### PR DESCRIPTION
The crypto currency wallet provider randomly rotates the IDs
so we have to remove them or risk donations going to unknown
places.